### PR TITLE
Fixing is_new() and load_from_s3()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ src
 *.pyc
 run.py
 .Python
+letslambda.zip
+package

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+PIP=	pip3.8
+
+letslambda.zip: letslambda.py requirements.txt
+	@$(MAKE) clean
+	mkdir package
+	$(PIP) install --target=./package -r requirements.txt
+	cd package ; zip -r ../$@ .
+	zip $@ letslambda.py
+
+clean:
+	rm -rf package letslambda.zip

--- a/letslambda.json
+++ b/letslambda.json
@@ -176,7 +176,7 @@
                 "Handler" : "letslambda.lambda_handler",
                 "MemorySize" : 128,
                 "Role" : {"Fn::GetAtt" : ["LambdaExecutionRole", "Arn"]},
-                "Runtime" : "python3.7",
+                "Runtime" : "python3.8",
                 "Timeout" : "240",
                 "Code": {
                     "S3Bucket": {"Ref": "Bucket"},

--- a/letslambda.py
+++ b/letslambda.py
@@ -135,11 +135,7 @@ def lambda_handler(event, context):
     request_certificate(conf)
 
 def is_new(conf):
-    try:
-        load_from_s3(conf, 'account.key.rsa')
-        return True
-    except:
-        return False
+    return load_from_s3(conf, conf["domain"]+".certificate.cert") == None
 
 def request_certificate(conf):
     dns_class = sewer.Route53Dns()
@@ -148,7 +144,8 @@ def request_certificate(conf):
     client = sewer.Client(domain_name=conf['domain'], 
                         domain_alt_names=conf['domain_alt_names'], 
                         contact_email=conf['contact_email'],
-                        dns_class=dns_class)
+                        dns_class=dns_class,
+                        account_key=load_from_s3("account.key.rsa"))
     if is_new(conf):
         print('requesting new certificate')
         certificate = client.cert()
@@ -162,8 +159,8 @@ def request_certificate(conf):
     # openssl x509 -in some_certificate_and_chain.crt -text -noout
     account_key = client.account_key
     print("your certificate is:", certificate)
-    print("your certificate's key is:", certificate_key)
-    print("your letsencrypt.org account key is:", account_key)
+    #print("your certificate's key is:", certificate_key)
+    #print("your letsencrypt.org account key is:", account_key)
     save_certificates_to_s3(conf, certificate, certificate_key, account_key)
     # NB: your certificate_key and account_key should be SECRET.
     # keep them very safe.

--- a/letslambda.py
+++ b/letslambda.py
@@ -35,7 +35,7 @@ def load_from_s3(conf, s3_key):
         LOG.error("Error: {0}".format(e))
         return None
 
-    return content
+    return content.decode("utf-8")
 
 def load_config(s3, s3_bucket, letslambda_config):
     """
@@ -141,11 +141,13 @@ def request_certificate(conf):
     dns_class = sewer.Route53Dns()
     # https://github.com/komuw/sewer/blob/43c3c8efae36489939d93096579ec54e941f67c7/sewer/client.py
     # 1. to create a new certificate:
+    # Increase ACME_AUTH_STATUS_MAX_CHECKS for a timeout of about 60s.
     client = sewer.Client(domain_name=conf['domain'], 
-                        domain_alt_names=conf['domain_alt_names'], 
-                        contact_email=conf['contact_email'],
-                        dns_class=dns_class,
-                        account_key=load_from_s3(conf, "account.key.rsa"))
+                          domain_alt_names=conf['domain_alt_names'],
+                          contact_email=conf['contact_email'],
+                          dns_class=dns_class,
+                          account_key=load_from_s3(conf, "account.key.rsa"),
+                          ACME_AUTH_STATUS_MAX_CHECKS=8)
     if is_new(conf):
         print('requesting new certificate')
         certificate = client.cert()

--- a/letslambda.py
+++ b/letslambda.py
@@ -145,7 +145,7 @@ def request_certificate(conf):
                         domain_alt_names=conf['domain_alt_names'], 
                         contact_email=conf['contact_email'],
                         dns_class=dns_class,
-                        account_key=load_from_s3("account.key.rsa"))
+                        account_key=load_from_s3(conf, "account.key.rsa"))
     if is_new(conf):
         print('requesting new certificate')
         certificate = client.cert()


### PR DESCRIPTION
Just a couple of fixes.

load_from_s3() was returning `bytes` instead of `str`. This is probably a Python 2-> 3 thing. 

is_new() was checking to see if the account key already exists instead of the certificate.